### PR TITLE
bug fix. use ms unit for '--ipv4-timeout' in live555.cpp

### DIFF
--- a/modules/access/live555.cpp
+++ b/modules/access/live555.cpp
@@ -530,7 +530,7 @@ static bool wait_Live555_response( demux_t *p_demux, int i_timeout = 0 /* ms */ 
     if( i_timeout > 0 )
     {
         /* Create a task that will be called if we wait more than timeout ms */
-        task = p_sys->scheduler->scheduleDelayedTask( i_timeout*1000,
+        task = p_sys->scheduler->scheduleDelayedTask( i_timeout,
                                                       TaskInterruptRTSP,
                                                       p_demux );
     }


### PR DESCRIPTION
* in tcp.c&libvlc-module.c, it's used as ms.